### PR TITLE
ci(release): 👷 add rollback gha workflow to rollback to a specific commit hash

### DIFF
--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -1,0 +1,71 @@
+---
+name: 🔙 Rollback
+run-name: 🔙 Rollback to ${{ inputs.commit }} Commit Hash by ${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit hash to rollback to (only the first 7 characters are needed)"
+        type: string
+        required: true
+
+permissions:
+  contents: write # Needed for the checkout action and to delete a release
+
+jobs:
+  rollback:
+    name: 🔙 Rollback to ${{ inputs.commit }} Commit Hash
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔑 Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: 🛒 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all tags
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: 🔧 Configure Git
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: 🔎 Validate Rollback Commit Exists
+        run: |
+          if ! git cat-file -e "${{ inputs.commit }}^{commit}"; then
+            echo "❌ Commit ${{ inputs.commit }} not found"
+            exit 1
+          fi
+
+      - name: 💣 Delete tags and GitHub Releases after Rollback Commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          { git log --pretty=format:"%H" ${{ inputs.commit }}..HEAD; echo; } | while read commit; do
+            if [ -n "$commit" ]; then
+              tags=$(git tag --points-at "$commit")
+              if [ -n "$tags" ]; then
+                for tag in $tags; do
+                  echo "Deleting tag $tag and its associated release"
+                  git push --delete origin "$tag"
+                  git tag -d "$tag"
+                  gh release delete "$tag" -y || echo "No release found for $tag, skipping..."
+                done
+              else
+                echo "No tags found for commit $commit"
+              fi
+            else
+              echo "Skipping empty commit hash..."
+            fi
+          done
+
+      - name: 🧨 Force reset and push
+        run: |
+          git reset --hard "${{ inputs.commit }}"
+          git push origin HEAD --force

--- a/.release-it.json
+++ b/.release-it.json
@@ -21,7 +21,7 @@
   },
   "hooks": {
     "after:bump": "npm run build && git add dist",
-    "before:release": "npm run contributors && git add CHANGELOG.md",
+    "before:release": "npm run contributors && npm run readme && git add CHANGELOG.md README.md",
     "after:release": "npm run patch && echo 'Successfully released ${name} v${version} to ${repo.repository}'"
   },
   "plugins": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "release:dry": "release-it --dry-run --ci",
     "release:info": "release-it --release-version",
     "contributors": "tsx scripts/contributors.ts",
+    "readme": "tsx scripts/readme.ts",
     "patch": "tsx scripts/patch.ts",
     "commit": "cz",
     "commitlint": "commitlint --edit",

--- a/scripts/contributors.ts
+++ b/scripts/contributors.ts
@@ -48,6 +48,11 @@ const repo = "solana-payout-action";
     }
   }
 
+  // If no username was found, set the username to the name
+  for (const [name, username] of authorToUsername) {
+    if (!username) authorToUsername.set(name, `@${name}`);
+  }
+
   // Get the changelog
   const changelog = fs.readFileSync(CHANGELOG_PATH, "utf-8");
 

--- a/scripts/readme.ts
+++ b/scripts/readme.ts
@@ -1,0 +1,37 @@
+import { Octokit } from "@octokit/rest";
+import fs from "fs";
+
+const README_PATH = "README.md";
+const PACKAGE_JSON_PATH = "package.json";
+
+const owner = "UraniumCorporation";
+const repo = "solana-payout-action";
+
+(async () => {
+  const octokit = new Octokit();
+  const latestRelease = await octokit.rest.repos.getLatestRelease({
+    owner,
+    repo
+  });
+  const latestVersionTag = latestRelease.data.tag_name;
+
+  // Get the current version from package.json (when running release-it, this will be the next version)
+  const nextVersion = fs.readFileSync(PACKAGE_JSON_PATH, "utf-8");
+  const nextVersionTag = JSON.parse(nextVersion).version;
+
+  // Get the changelog
+  const readme = fs.readFileSync(README_PATH, "utf-8");
+
+  // Replace the all instances of the latest version tag with the next version tag
+  const updatedReadme = readme.replace(
+    new RegExp(latestVersionTag, "g"),
+    `v${nextVersionTag}`
+  );
+
+  // Update the README examples using the next version tag
+  fs.writeFileSync(README_PATH, updatedReadme, "utf-8");
+
+  console.log(
+    `✅ Updated ${README_PATH} examples using the next version tag ${nextVersionTag}`
+  );
+})();


### PR DESCRIPTION
## Description

🔙 Add Rollback Support to Release Workflow

This PR introduces a new GitHub Actions workflow that allows maintainers to rollback the main branch to a specific commit.  
It performs a hard reset, deletes any tags and associated GitHub Releases created after the target commit, and force-pushes the updated state.

Other changes:
- 🔨 add readme script for release-it before:release hook to update the `README.md` examples to use the next version tag
- 📦 fallback missing contributor username to @author-name in contributors script

## Related Issues

- No rollback strategy and mechanism to a certain commit hash

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

In your own fork, run the github action workflow `🔙 Rollback` and input the commit hash you want your default branch to rollback to. Observe that the HEAD is now at the commit hash and all of the tags/releases ahead of the commit hash are all deleted

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
